### PR TITLE
Replace relationship fields with ancestor sibling selection

### DIFF
--- a/GOOGLE_SHEETS_SETUP.md
+++ b/GOOGLE_SHEETS_SETUP.md
@@ -149,19 +149,14 @@ The app will automatically create the following columns in your sheet:
 
 | Column | Description |
 |--------|-------------|
-| Timestamp | Date and time of registration |
-| ID | Unique identifier |
-| First Name | First name of family member |
-| Last Name | Last name of family member |
+| Name | Full name of family member |
 | Email | Email address |
 | Phone | Phone number |
-| Relationship Type | Type of family relationship |
-| Connected To | Who they're connected through |
+| Ancestor Sibling | Which sibling was parent/grandparent or great grandparent |
 | Generation | Generation number (1-5) |
-| Branch Description | Family branch description |
-| Number of Attendees | Number of people attending |
-| Photo URL | Path to uploaded photo |
-| Notes | Additional notes |
+| Family Branch | Family branch description |
+| Attendees | Number of people attending |
+| Created At | Date and time of registration |
 
 ## Testing the Integration
 
@@ -287,19 +282,14 @@ async function migrate() {
     const lastName = lastNameParts.join(' ');
 
     await sheet.addRow({
-      'Timestamp': member.createdAt || new Date().toISOString(),
-      'ID': member.id,
-      'First Name': firstName,
-      'Last Name': lastName,
+      'Name': member.name,
       'Email': member.email,
       'Phone': member.phone,
-      'Relationship Type': member.relationshipType,
-      'Connected To': member.connectedThrough,
+      'Ancestor Sibling': member.ancestorSibling,
       'Generation': member.generation.toString(),
-      'Branch Description': member.familyBranch,
-      'Number of Attendees': (member.attendees || 0).toString(),
-      'Photo URL': member.photo || '',
-      'Notes': ''
+      'Family Branch': member.familyBranch,
+      'Attendees': (member.attendees || 0).toString(),
+      'Created At': member.createdAt || new Date().toISOString()
     });
 
     console.log(`Migrated: ${member.name}`);

--- a/client/src/components/BottomSheet.jsx
+++ b/client/src/components/BottomSheet.jsx
@@ -98,8 +98,7 @@ function BottomSheet({ isOpen, onClose, member }) {
 
           {/* Details Grid */}
           <div className="space-y-1">
-            <DetailItem label="Relationship" value={member.relationshipType} />
-            <DetailItem label="Connected Through" value={member.connectedThrough} />
+            <DetailItem label="Ancestor Sibling" value={member.ancestorSibling} />
             <DetailItem label="Generation" value={`Generation ${member.generation}`} />
             <DetailItem label="Family Branch" value={member.familyBranch} />
             <DetailItem label="Attendees" value={member.attendees?.toString()} />

--- a/client/src/pages/Admin.jsx
+++ b/client/src/pages/Admin.jsx
@@ -188,13 +188,12 @@ function Admin() {
     : familyData.filter(member => member.generation === parseInt(filter));
 
   const downloadCSV = () => {
-    const headers = ['Name', 'Email', 'Phone', 'Relationship', 'Connected Through', 'Generation', 'Branch', 'Attendees'];
+    const headers = ['Name', 'Email', 'Phone', 'Ancestor Sibling', 'Generation', 'Branch', 'Attendees'];
     const csvData = filteredData.map(member => [
       member.name,
       member.email,
       member.phone,
-      member.relationshipType,
-      member.connectedThrough,
+      member.ancestorSibling,
       member.generation,
       member.familyBranch,
       member.attendees
@@ -371,7 +370,7 @@ function Admin() {
                     <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider">Photo</th>
                     <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider">Name</th>
                     <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider hidden md:table-cell">Contact</th>
-                    <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider hidden lg:table-cell">Relationship</th>
+                    <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider hidden lg:table-cell">Ancestor Sibling</th>
                     <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider">Generation</th>
                     <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider hidden xl:table-cell">Branch</th>
                     <th className="px-6 py-4 text-left text-xs font-semibold text-neutral-600 uppercase tracking-wider">Attendees</th>
@@ -396,14 +395,14 @@ function Admin() {
                       </td>
                       <td className="px-6 py-4">
                         <div className="text-sm font-medium text-neutral-900">{member.name}</div>
-                        <div className="text-xs text-neutral-500">via {member.connectedThrough}</div>
+                        <div className="text-xs text-neutral-500">via {member.ancestorSibling}</div>
                       </td>
                       <td className="px-6 py-4 hidden md:table-cell">
                         <div className="text-sm text-neutral-900">{member.email}</div>
                         <div className="text-xs text-neutral-500">{member.phone}</div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900 hidden lg:table-cell">
-                        {member.relationshipType}
+                        {member.ancestorSibling}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
                         <span className="inline-flex items-center px-3 py-1 text-xs font-medium rounded-full bg-orange-100 text-orange-700">

--- a/client/src/pages/FamilyTree.jsx
+++ b/client/src/pages/FamilyTree.jsx
@@ -37,8 +37,7 @@ function FamilyTree() {
     const query = searchQuery.toLowerCase();
     return familyData.filter(member =>
       member.name.toLowerCase().includes(query) ||
-      member.relationshipType?.toLowerCase().includes(query) ||
-      member.connectedThrough?.toLowerCase().includes(query) ||
+      member.ancestorSibling?.toLowerCase().includes(query) ||
       member.familyBranch?.toLowerCase().includes(query)
     );
   }, [familyData, searchQuery]);
@@ -101,7 +100,7 @@ function FamilyTree() {
           {/* Search Bar */}
           <SearchBar
             onSearch={handleSearch}
-            placeholder="Search by name, relationship, or branch..."
+            placeholder="Search by name, ancestor sibling, or branch..."
           />
 
           {/* Search Results Indicator */}
@@ -232,10 +231,7 @@ function MemberCard({ member, onClick, style }) {
             {member.name}
           </h3>
           <p className="text-sm text-neutral-600 truncate">
-            {member.relationshipType}
-          </p>
-          <p className="text-xs text-neutral-500 truncate">
-            via {member.connectedThrough}
+            via {member.ancestorSibling}
           </p>
         </div>
 

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -11,8 +11,7 @@ function Register() {
     name: '',
     email: '',
     phone: '',
-    relationshipType: '',
-    connectedThrough: '',
+    ancestorSibling: '',
     generation: '',
     familyBranch: '',
     attendees: '1'
@@ -179,37 +178,23 @@ function Register() {
             />
           </div>
 
-          {/* Relationship Type */}
+          {/* Ancestor Sibling */}
           <FloatingLabelSelect
-            label="Relationship Type"
-            name="relationshipType"
-            value={formData.relationshipType}
+            label="Which sibling was your parent/grandparent or great grandparent?"
+            name="ancestorSibling"
+            value={formData.ancestorSibling}
             onChange={handleInputChange}
             required
             options={[
               { value: '', label: '' },
-              { value: 'Immediate Family', label: 'Immediate Family' },
-              { value: 'Spouse', label: 'Spouse' },
-              { value: 'Child', label: 'Child' },
-              { value: 'Grandchild', label: 'Grandchild' },
-              { value: 'Sibling', label: 'Sibling' },
-              { value: 'Cousin', label: 'Cousin' },
-              { value: 'Aunt/Uncle', label: 'Aunt/Uncle' },
-              { value: 'Niece/Nephew', label: 'Niece/Nephew' },
-              { value: 'In-law', label: 'In-law' },
-              { value: 'Other', label: 'Other' }
+              { value: 'Arturo', label: 'Arturo' },
+              { value: 'Domingo', label: 'Domingo' },
+              { value: 'Ernesto', label: 'Ernesto' },
+              { value: 'Josefa', label: 'Josefa' },
+              { value: 'David', label: 'David' },
+              { value: 'Julia', label: 'Julia' },
+              { value: 'Francisco', label: 'Francisco' }
             ]}
-          />
-
-          {/* Connected Through */}
-          <FloatingLabelInput
-            label="Connected Through"
-            name="connectedThrough"
-            type="text"
-            value={formData.connectedThrough}
-            onChange={handleInputChange}
-            required
-            helper="e.g., Abuela Alma, Julieta Madrigal"
           />
 
           {/* Generation & Attendees */}

--- a/server/server.js
+++ b/server/server.js
@@ -230,13 +230,13 @@ async function getRegistrationsFromSheet() {
   try {
     const response = await sheets.spreadsheets.values.get({
       spreadsheetId: GOOGLE_SHEET_ID,
-      range: 'Sheet1!A:I'
+      range: 'Sheet1!A:G'
     });
 
     const rows = response.data.values || [];
 
     // Skip header row if it exists, map data to expected format
-    // Columns: Name, Email, Phone, RelationshipType, ConnectedThrough, Generation, FamilyBranch, Attendees, CreatedAt
+    // Columns: Name, Email, Phone, AncestorSibling, Generation, FamilyBranch, Attendees, CreatedAt
     const registrations = [];
     let hasHeader = rows.length > 0 && (rows[0][0] === 'Name' || rows[0][0] === 'name');
 
@@ -260,12 +260,11 @@ async function getRegistrationsFromSheet() {
         name: row[0] || '',
         email: row[1] || '',
         phone: row[2] || '',
-        relationshipType: row[3] || '',
-        connectedThrough: row[4] || '',
-        generation: parseInt(row[5]) || 0,
-        familyBranch: row[6] || '',
-        attendees: parseInt(row[7]) || 1,
-        createdAt: row[8] || new Date().toISOString()
+        ancestorSibling: row[3] || '',
+        generation: parseInt(row[4]) || 0,
+        familyBranch: row[5] || '',
+        attendees: parseInt(row[6]) || 1,
+        createdAt: row[7] || new Date().toISOString()
       });
     }
 
@@ -298,8 +297,7 @@ async function appendToGoogleSheet(memberData) {
       memberData.name,
       memberData.email,
       memberData.phone,
-      memberData.relationshipType,
-      memberData.connectedThrough,
+      memberData.ancestorSibling,
       memberData.generation,
       memberData.familyBranch,
       memberData.attendees,
@@ -308,7 +306,7 @@ async function appendToGoogleSheet(memberData) {
 
     const request = {
       spreadsheetId: GOOGLE_SHEET_ID,
-      range: 'Sheet1!A:I', // Adjust sheet name if needed
+      range: 'Sheet1!A:H', // Adjust sheet name if needed
       valueInputOption: 'USER_ENTERED',
       insertDataOption: 'INSERT_ROWS',
       resource: {
@@ -351,8 +349,7 @@ app.post('/api/register', upload.single('photo'), async (req, res) => {
       name: sanitizeString(req.body.name, 100),
       email: email,
       phone: sanitizeString(req.body.phone, 20),
-      relationshipType: sanitizeString(req.body.relationshipType, 50),
-      connectedThrough: sanitizeString(req.body.connectedThrough, 100),
+      ancestorSibling: sanitizeString(req.body.ancestorSibling, 50),
       generation: parseInt(req.body.generation) || 0,
       familyBranch: sanitizeString(req.body.familyBranch, 100),
       photo: req.file ? `/uploads/${req.file.filename}` : null,

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,13 @@ function validateEmail(email) {
   return emailRegex.test(email);
 }
 
+// Valid ancestor siblings
+const VALID_SIBLINGS = ['Arturo', 'Domingo', 'Ernesto', 'Josefa', 'David', 'Julia', 'Francisco'];
+
+function validateAncestorSibling(value) {
+  return VALID_SIBLINGS.includes(value);
+}
+
 // Ensure directories exist
 async function ensureDirectories() {
   try {
@@ -230,7 +237,7 @@ async function getRegistrationsFromSheet() {
   try {
     const response = await sheets.spreadsheets.values.get({
       spreadsheetId: GOOGLE_SHEET_ID,
-      range: 'Sheet1!A:G'
+      range: 'Sheet1!A:H'
     });
 
     const rows = response.data.values || [];
@@ -344,12 +351,21 @@ app.post('/api/register', upload.single('photo'), async (req, res) => {
       });
     }
 
+    // Validate ancestorSibling
+    const ancestorSibling = sanitizeString(req.body.ancestorSibling, 50);
+    if (!validateAncestorSibling(ancestorSibling)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid ancestor sibling selection'
+      });
+    }
+
     const newMember = {
       id: Date.now().toString(),
       name: sanitizeString(req.body.name, 100),
       email: email,
       phone: sanitizeString(req.body.phone, 20),
-      ancestorSibling: sanitizeString(req.body.ancestorSibling, 50),
+      ancestorSibling: ancestorSibling,
       generation: parseInt(req.body.generation) || 0,
       familyBranch: sanitizeString(req.body.familyBranch, 100),
       photo: req.file ? `/uploads/${req.file.filename}` : null,


### PR DESCRIPTION
- Replace relationshipType dropdown with ancestorSibling field
- Remove connectedThrough field from form and data structure
- Update registration form with new field: "Which sibling was your parent/grandparent or great grandparent?"
- Add 7 sibling options: Arturo, Domingo, Ernesto, Josefa, David, Julia, Francisco
- Update Google Sheets integration to use new column structure (A:H)
- Update Admin dashboard to display ancestor sibling info
- Update Family Tree search and display
- Update BottomSheet details view
- Update documentation with new field structure

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)