### PR TITLE
Fix direct URL routing for client-side routes

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -748,13 +748,14 @@ Promise.all([
   initializeGalleryFile()
 ]).then(() => {
   // Serve static files from React build
-const path = require('path');
-app.use(express.static(path.join(__dirname, '../client/dist')));
+  app.use(express.static(path.join(__dirname, '../client/dist')));
 
-// Handle client-side routing - this must be LAST, after all API routes
-app.use((req, res) => {
-  res.sendFile(path.join(__dirname, '../client/dist/index.html'));
-});app.listen(PORT, () => {
+  // Handle client-side routing - this must be LAST, after all API routes
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(__dirname, '../client/dist/index.html'));
+  });
+
+  app.listen(PORT, () => {
     console.log(`Server running on http://localhost:${PORT}`);
   });
 });


### PR DESCRIPTION
Fixes #15

### Changes
- Changed catch-all route from `app.use()` to `app.get('*', ...)`
- Fixed syntax error in server startup code
- Ensures React app serves index.html for all non-API routes
- Resolves 404 errors when navigating directly to /register

Generated with [Claude Code](https://claude.ai/code)