### PR TITLE
Fix: Move catch-all route outside Promise callback

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -742,20 +742,24 @@ app.delete('/api/gallery/:id', async (req, res) => {
 // START SERVER
 // ==========================================
 
+// Initialize directories and data files on startup
 Promise.all([
   ensureDirectories(),
   initializeDataFile(),
   initializeGalleryFile()
-]).then(() => {
-  // Serve static files from React build
-  app.use(express.static(path.join(__dirname, '../client/dist')));
+]).catch(error => {
+  console.error('Initialization error:', error);
+});
 
-  // Handle client-side routing - this must be LAST, after all API routes
-  app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '../client/dist/index.html'));
-  });
+// Serve static files from React build
+app.use(express.static(path.join(__dirname, '../client/dist')));
 
-  app.listen(PORT, () => {
-    console.log(`Server running on http://localhost:${PORT}`);
-  });
+// Catch-all route for client-side routing - must be LAST
+app.get('*', (req, res) => {
+  console.log('Catch-all route hit:', req.path);
+  res.sendFile(path.join(__dirname, '../client/dist/index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
The catch-all route was inside a Promise.all().then() callback, which caused it to only register after the Promise resolved. This led to 404 errors when directly navigating to or refreshing client-side routes like /register.

## Changes
- Moved static file serving and catch-all route to top level
- Ensured catch-all route is after all API routes but before app.listen()
- Added console.log for debugging route hits
- Changed Promise to use .catch() so initialization doesn't block route registration

Fixes #17

Generated with [Claude Code](https://claude.ai/code)