### PR TITLE
Fix API URL for static site deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@ client/build/
 # Environment variables
 .env
 .env.local
-.env.production
 .env.development
+# Note: .env.production is tracked because it contains non-sensitive public API URL
 
 # Uploads folder contents (keep folder, ignore contents)
 server/uploads/*

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,0 +1,2 @@
+# Production API URL - Backend deployed on Render
+VITE_API_URL=https://madrigal-reunion.onrender.com


### PR DESCRIPTION
## Summary
Fixed API URL configuration for static site deployment on Render.

## Changes
- Added `.env.production` with backend URL for production builds
- Updated `.gitignore` to track `.env.production` (contains public API URL)

## Testing
After merging, rebuild the static site on Render to pick up the new configuration.

Fixes #20

Generated with [Claude Code](https://claude.ai/code)