### PR TITLE
Fix CORS for static site deployment

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -18,13 +18,13 @@ const GOOGLE_SERVICE_ACCOUNT_EMAIL = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
 const GOOGLE_PRIVATE_KEY = process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, '\n');
 
 // Middleware - CORS configuration
-const corsOptions = {
-  origin: NODE_ENV === 'production'
-    ? [CLIENT_URL] // Only allow specific origin in production
-    : '*', // Allow all origins in development
+app.use(cors({
+  origin: [
+    'https://madrigal-family-reunion.onrender.com',
+    'http://localhost:5173' // for local development
+  ],
   credentials: true
-};
-app.use(cors(corsOptions));
+}));
 app.use(express.json());
 app.use('/uploads', express.static('uploads'));
 app.use('/gallery', express.static('gallery'));


### PR DESCRIPTION
Fixes #22

Updated CORS configuration in server/server.js to explicitly allow requests from the production frontend URL (https://madrigal-family-reunion.onrender.com) and localhost for development.

This resolves the network errors on registration and the "Unable to load stats" error on the home page.

**Changes:**
- Replaced environment-variable-based CORS config with explicit origin list
- Added production frontend URL to allowed origins
- Maintained localhost:5173 for local development
- Kept credentials: true for session support

Generated with [Claude Code](https://claude.ai/code)