### PR TITLE
Fix catch-all route syntax for Express 5

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -755,7 +755,7 @@ Promise.all([
 app.use(express.static(path.join(__dirname, '../client/dist')));
 
 // Catch-all route for client-side routing - must be LAST
-app.get('*', (req, res) => {
+app.get('/(.*)', (req, res) => {
   console.log('Catch-all route hit:', req.path);
   res.sendFile(path.join(__dirname, '../client/dist/index.html'));
 });


### PR DESCRIPTION
This PR fixes the backend crash on startup caused by incompatible catch-all route syntax.

### Changes
- Updated the catch-all route in `server/server.js:758` from `app.get('*', ...)` to `app.get('/(.*)', ...)`
- This resolves the PathError with Express 5 and path-to-regexp

Fixes #24

Generated with [Claude Code](https://claude.ai/code)