### PR TITLE
Remove catch-all route and static file serving from backend

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -751,15 +751,6 @@ Promise.all([
   console.error('Initialization error:', error);
 });
 
-// Serve static files from React build
-app.use(express.static(path.join(__dirname, '../client/dist')));
-
-// Catch-all route for client-side routing - must be LAST
-app.get('/(.*)', (req, res) => {
-  console.log('Catch-all route hit:', req.path);
-  res.sendFile(path.join(__dirname, '../client/dist/index.html'));
-});
-
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
The frontend is now deployed as a separate static site on Render, so the backend no longer needs to serve the React app. This resolves crashes caused by the catch-all route syntax.

### Changes
- Removed static file serving middleware for client/dist
- Removed catch-all route that served index.html

The backend now only serves API routes.

Fixes #26

Generated with [Claude Code](https://claude.ai/code)