### PR TITLE
Fix QR code URL to point to frontend

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -17,7 +17,7 @@ function Home() {
 
   useEffect(() => {
     // Generate QR code
-    const registrationUrl = window.location.origin + '/register';
+    const registrationUrl = 'https://madrigal-family-reunion.onrender.com/register';
     if (canvasRef.current) {
       QRCode.toCanvas(canvasRef.current, registrationUrl, {
         width: 200,


### PR DESCRIPTION
Updates the QR code in Home.jsx to use the frontend URL (https://madrigal-family-reunion.onrender.com/register) instead of window.location.origin.

Fixes #28

Generated with [Claude Code](https://claude.ai/code)